### PR TITLE
Fixed exception message spelling

### DIFF
--- a/IdentityModel/Thinktecture.IdentityModel/Tokens/HmacSigningCredentials.cs
+++ b/IdentityModel/Thinktecture.IdentityModel/Tokens/HmacSigningCredentials.cs
@@ -32,7 +32,7 @@ namespace Thinktecture.IdentityModel.Tokens
                 case 64:
                     return Algorithms.HmacSha512Signature;
                 default:
-                    throw new InvalidOperationException("Unsupported key lenght");
+                    throw new InvalidOperationException("Unsupported key length");
             }
         }
 


### PR DESCRIPTION
lenght -> length in HmacSigningCredentials.cs